### PR TITLE
Refactor: Add placeholders for ML model integration

### DIFF
--- a/core/cnn_patterns.py
+++ b/core/cnn_patterns.py
@@ -1,5 +1,7 @@
 # core/cnn_patterns.py
 import logging
+import os # Added for MODELS_DIR
+import json # Added for json.dumps
 from typing import List, Dict, Any, Tuple, Optional
 import pandas as pd
 import numpy as np
@@ -16,8 +18,39 @@ class CNNPatterns:
     voor complexere CNN-patroonherkenning.
     """
 
+    # Pad voor het opslaan/laden van getrainde modellen
+    # Gebruik 'data/models' zoals gespecificeerd in de prompt, niet 'models' zoals in pre_trainer
+    MODELS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'data', 'models')
+    os.makedirs(MODELS_DIR, exist_ok=True)
+
+
     def __init__(self):
+        self.loaded_models: Dict[str, Any] = {} # Om geladen ML-modellen op te slaan
+        self._load_ml_models() # Poging om ML-modellen te laden bij initialisatie
         logger.info("CNNPatterns geïnitialiseerd.")
+
+    def _load_ml_models(self):
+        """
+        Laadt getrainde Deep Learning-modellen voor patroonherkenning.
+        Dit is een **placeholder** voor de daadwerkelijke modellading.
+        """
+        logger.info(f"Poging om ML-modellen te laden vanuit {CNNPatterns.MODELS_DIR}...")
+
+        # Placeholder: Geen modellen worden daadwerkelijk geladen.
+        # Verwijder of commentarieer alle voorbeeld Keras/PyTorch laadlogica.
+
+        if not self.loaded_models: # Dit zal altijd waar zijn voor de placeholder
+            logger.info("Geen Deep Learning-modellen geladen. CNNPatterns zal regelgebaseerd functioneren.")
+
+    def _predict_pattern_score(self, model_name: str, input_data: np.ndarray) -> float:
+        """
+        Voert inferentie uit met een geladen ML-model om een patroonscore te voorspellen.
+        Dit is een **placeholder** voor de daadwerkelijke inferentie.
+        """
+        # Verwijder of commentarieer alle voorbeeld Keras/PyTorch voorspellingslogica.
+
+        logger.debug(f"Simuleren voorspelling voor model {model_name} met input shape {input_data.shape if input_data is not None else 'N/A'}.")
+        return np.random.rand() # Return a random score (0-1) as a placeholder simulation
 
     # --- Helperfuncties voor dataverwerking (uitbreiding van Freqtrade DF naar 'candles' dicts) ---
     def _dataframe_to_candles(self, dataframe: pd.DataFrame) -> List[Dict[str, Any]]:
@@ -704,8 +737,25 @@ class CNNPatterns:
             "context": ['1h', '4h', '12h', '1d', '1w']
         }
 
-        # Zorg dat alle timeframes beschikbaar zijn in de input
-        available_timeframes = candles_by_timeframe.keys()
+        # --- ML Model Inference (Placeholder Integration) ---
+        if not self.loaded_models:
+            logger.info("Geen ML modellen geladen, overgeslagen ML-gebaseerde patroon detectie.")
+        else:
+            logger.info(f"Starten van ML-gebaseerde patroon detectie voor {len(self.loaded_models)} modellen...")
+            for model_name, ml_model_instance in self.loaded_models.items(): # ml_model_instance is not used yet
+                # In a real scenario, prepare specific input_data for each model
+                # For this placeholder, we'll use a dummy array.
+                logger.info(f"Voorbereiden van dummy input data voor ML model: {model_name}")
+                dummy_input_data = np.array([]) # Placeholder for actual data preparation
+
+                # Call the placeholder prediction method
+                score = self._predict_pattern_score(model_name, dummy_input_data)
+                pattern_key = f"ml_{model_name}_score"
+                all_patterns["patterns"][pattern_key] = score
+                logger.info(f"ML Model '{model_name}' gesimuleerde score: {score:.4f} (opgeslagen als {pattern_key})")
+
+        # --- Regelgebaseerde detectie (bestaande logica) ---
+        available_timeframes = candles_by_timeframe.keys() # Ensure this is defined before use
         for tf_group in TIME_FRAME_CONFIG.values():
             for tf_val in tf_group:
                  if tf_val not in available_timeframes:
@@ -809,7 +859,7 @@ class CNNPatterns:
             all_patterns["context"]["volume_spike"] = False
 
 
-        logger.debug(f"Patroondetectie resultaat voor {symbol}: {json.dumps(all_patterns, indent=2)}")
+        logger.debug(f"Patroondetectie resultaat voor {symbol}: {json.dumps(all_patterns, indent=2, default=str)}") # Added default=str
         return all_patterns
 
 # Voorbeeld van hoe je het zou kunnen gebruiken (voor testen)
@@ -817,7 +867,7 @@ if __name__ == "__main__":
     import asyncio
     import pandas as pd
     from datetime import datetime, timedelta
-    import os # Toegevoegd voor os.path.join
+    # import os # os is already imported at the top level
     import json # Toegevoegd voor json.dumps in test
     import dotenv
     # Corrected path for .env when running this script directly
@@ -910,7 +960,11 @@ if __name__ == "__main__":
         # logger.info("Starting multi-timeframe pattern detection test...")
         detected_patterns = await cnn_detector.detect_patterns_multi_timeframe(candles_by_timeframe, test_symbol)
 
-        print(json.dumps(detected_patterns, indent=2, default=str)) # Added default=str for datetime if any
+    # Ensure logger is configured for __main__ to see output if using logger.debug in detect_patterns_multi_timeframe
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+
+    print(json.dumps(detected_patterns, indent=2, default=str))
 
         print("\n--- Specifieke patroon tests op 5m ---")
         mock_5m_df = candles_by_timeframe['5m']

--- a/core/pre_trainer.py
+++ b/core/pre_trainer.py
@@ -16,8 +16,10 @@ logger.setLevel(logging.INFO)
 MEMORY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'memory')
 PRETRAIN_LOG_FILE = os.path.join(MEMORY_DIR, 'pre_train_log.json')
 TIME_EFFECTIVENESS_FILE = os.path.join(MEMORY_DIR, 'time_effectiveness.json')
+MODELS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'models') # For mock model paths
 
 os.makedirs(MEMORY_DIR, exist_ok=True)
+os.makedirs(MODELS_DIR, exist_ok=True) # Ensure MODELS_DIR is created
 
 class PreTrainer:
     """
@@ -140,38 +142,39 @@ class PreTrainer:
 
     async def train_ai_models(self, training_data: pd.DataFrame, model_type: str = 'cnn_pattern_recognizer'):
         """
-        Traingt AI-modellen (bijv. CNN's) op de voorbereide data.
+        Simuleert het trainen van AI-modellen. Verwijdert daadwerkelijke ML-bibliotheekaanroepen.
         """
-        if training_data.empty:
-            logger.warning(f"Geen trainingsdata beschikbaar voor model '{model_type}'. Training overgeslagen.")
-            return
-
         logger.info(f"Simuleren training van AI-model '{model_type}' met {len(training_data)} samples...")
 
-        # Placeholder voor daadwerkelijke ML training
-        # Voorbeeld:
-        # if model_type == 'cnn_pattern_recognizer':
-        #     # features = training_data[['open', 'high', 'low', 'close', 'volume', 'rsi', ...]]
-        #     # labels = training_data['cnn_bull_flag_label']
-        #     # Train model...
-        # elif model_type == 'trade_outcome_predictor':
-        #     # features = ...
-        #     # labels = training_data['trade_outcome_label']
-        #     # Train model...
+        if training_data.empty:
+            logger.warning(f"Geen trainingsdata voor model '{model_type}'. Training overgeslagen.")
+            return
 
-        await asyncio.sleep(1) # Simuleer trainingstijd
+        # --- REMOVE ACTUAL DEEP LEARNING TRAINING LOGIC ---
+        # Keras/TensorFlow related code should be removed from here.
+
+        # For current placeholder, just log the simulation.
+        mock_model_save_path = os.path.join(MODELS_DIR, f"{model_type}_model_simulated.h5")
+        logger.info(f"Simulatie: AI-model '{model_type}' zou getraind en opgeslagen worden op {mock_model_save_path}.")
+
+        # Log pretrain activity
+        # Ensure this call remains and uses a simulated path
+        await asyncio.to_thread(self._log_pretrain_activity, model_type, len(training_data), model_path=mock_model_save_path)
+
         logger.info(f"AI-model '{model_type}' succesvol gesimuleerd getraind.")
-        await asyncio.to_thread(self._log_pretrain_activity, model_type, len(training_data))
 
 
-    def _log_pretrain_activity(self, model_type: str, data_size: int):
+    def _log_pretrain_activity(self, model_type: str, data_size: int, model_path: str = None):
         """ Logt de pre-trainingsactiviteit. """
         entry = {
             "timestamp": datetime.now().isoformat(),
             "model_type": model_type,
             "data_size": data_size,
-            "status": "completed_simulation" # Duidelijker maken dat het simulatie is
+            "status": "completed_simulation"
         }
+        if model_path:
+            entry["model_path"] = model_path
+
         logs = []
         try:
             if os.path.exists(PRETRAIN_LOG_FILE) and os.path.getsize(PRETRAIN_LOG_FILE) > 0:


### PR DESCRIPTION
This commit introduces placeholder functionalities in `core/pre_trainer.py` and `core/cnn_patterns.py` to prepare for future Machine Learning model integration.

Key changes:

1.  **`core/pre_trainer.py`**:
    *   The `train_ai_models` function has been updated to be a placeholder. It now simulates the idea of model training and saving without invoking any actual ML libraries. It logs its simulated actions and records activity in the pre-train log with a mock model path.

2.  **`core/cnn_patterns.py`**:
    *   Added a placeholder method `_load_ml_models` to the `CNNPatterns` class. This method simulates the loading of ML models and logs its actions. Currently, it does not load any actual models.
    *   Added a placeholder method `_predict_pattern_score` to the `CNNPatterns` class. This method simulates model inference, returning a random score.
    *   The `detect_patterns_multi_timeframe` method has been updated to include a section that (currently) simulates calls to `_predict_pattern_score` for any loaded models (though none are loaded by the placeholder `_load_ml_models`). The results of these simulated predictions are added to the output.

These changes ensure that the modules are structurally ready for the integration of real Deep Learning models while maintaining current rule-based functionalities.