### PR TITLE
I've updated the `exchange.pair_whitelist` in `config/config.json` to…

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -20,7 +20,10 @@
       "USDC/USDT",
       "WBTC/USDT",
       "LINK/USDT",
-      "UNI/USDT"
+      "UNI/USDT",
+      "ZEN/BTC",
+      "LSK/BTC",
+      "ETH/BTC"
     ],
     "pair_blacklist": [],
     "markets": {


### PR DESCRIPTION
… include the following trading pairs:

- ETH/EUR
- BTC/EUR
- ZEN/EUR
- WETH/USDT
- USDC/USDT
- WBTC/USDT
- LINK/USDT
- UNI/USDT
- ZEN/BTC
- LSK/BTC
- ETH/BTC

This aligns the configuration with your specified Bitvavo integration requirements.