### PR TITLE
Docs: Add links to testing frameworks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ De workflow is grotendeels geïmplementeerd op algoritmisch niveau en de AI-modu
     * **Optimalisatie:** Documenteer de beperking en adviseer periodieke handmatige synchronisatie of onderzoek geavanceerde Freqtrade extensies voor dynamisch pairlist management.
 
 -   **Teststructuur (Formele Unit Tests):**
-    * **Ontbrekend:** Hoewel de `if __name__ == "__main__":` blokken zijn toegevoegd voor elk Python-bestand, is een **formele, geautomatiseerde testsuite met `pytest` cruciaal** voor robuustheid en kwaliteitsborging.
+    * **Ontbrekend:** Hoewel de `if __name__ == "__main__":` blokken zijn toegevoegd voor elk Python-bestand, is een **formele, geautomatiseerde testsuite met `pytest` cruciaal** voor robuustheid en kwaliteitsborging. Voor meer informatie over deze frameworks, zie de [pytest documentatie](https://docs.pytest.org/) en de [unittest documentatie](https://docs.python.org/3/library/unittest.html).
     * **Prioriteit:** **Hoog**.
 
 ## Toekomstige Ontwikkeling


### PR DESCRIPTION
I've added links to the official documentation for pytest and unittest in the 'Teststructuur (Formele Unit Tests)' section of the README.md to provide helpful resources for you if you're interested in the testing strategy.