### PR TITLE
Refactor: Use common strongPatternThreshold and ensure cnnPatternWeig…

### DIFF
--- a/core/exit_optimizer.py
+++ b/core/exit_optimizer.py
@@ -172,13 +172,13 @@ class ExitOptimizer:
 
         logger.info(f"Symbol: {symbol} (Exit), Final Calculated Weighted Bearish Pattern Score: {weighted_pattern_score:.2f} from patterns: [{'; '.join(detected_patterns_summary)}]")
 
-        # Fetch strong_bearish_pattern_threshold from ParamsManager
+        # Fetch strong_bearish_pattern_threshold from ParamsManager using the common key
         strong_bearish_pattern_threshold = self.params_manager.get_param(
-            "strongBearishPatternThresholdExit",
+            "strongPatternThreshold", # Common parameter key
             strategy_id=current_strategy_id,
-            default=0.5 # Default value if not found in params.json
+            default=0.5
         )
-        logger.info(f"Symbol: {symbol} (Exit), Using strongBearishPatternThresholdExit: {strong_bearish_pattern_threshold} (Strategy: {current_strategy_id}, Default: 0.5)")
+        logger.info(f"Symbol: {symbol} (Exit), Using common strongPatternThreshold: {strong_bearish_pattern_threshold} (Strategy: {current_strategy_id}, Default: 0.5)")
 
         is_strong_bearish_pattern = weighted_pattern_score >= strong_bearish_pattern_threshold
 
@@ -497,12 +497,12 @@ if __name__ == "__main__":
         print("\n--- Test Scenario 1A: Strong Bearish Pattern (Rule + CNN), Custom Threshold (0.6) - EXIT ---")
         current_mock_params = {
             "exitConvictionDropTrigger": 0.4,
-            "cnnPatternWeight": 0.8, # Custom weight
-            "strongBearishPatternThresholdExit": 0.6,
+            "cnnPatternWeight": 0.8,
+            "strongPatternThreshold": 0.6, # Using common key for the test
             "exitPatternConfThreshold": 0.5,
             "exitAISellIntentConfThreshold": 0.6,
             "minProfitForLowConfExit": 0.005,
-            "exitRulePatternScore": 0.7 # Default rule score
+            "exitRulePatternScore": 0.7
         }
         optimizer.params_manager.get_param = lambda key, strategy_id=None, default=None: current_mock_params.get(key, default)
 
@@ -538,7 +538,7 @@ if __name__ == "__main__":
         current_mock_params = {
             "exitConvictionDropTrigger": 0.4,
             "cnnPatternWeight": 1.0,
-            "strongBearishPatternThresholdExit": 0.8, # Higher threshold
+            "strongPatternThreshold": 0.8, # Using common key for the test
             "exitPatternConfThreshold": 0.5,
             "exitAISellIntentConfThreshold": 0.6,
             "minProfitForLowConfExit": 0.005,
@@ -566,11 +566,14 @@ if __name__ == "__main__":
 
         # Scenario 1C: Strong Rule Pattern, Default Thresholds (exitRulePatternScore=0.7, strongBearishPatternThresholdExit=0.5), No CNN - Exit
         print("\n--- Test Scenario 1C: Strong Rule Pattern, Default Thresholds, No CNN - EXIT ---")
-        current_mock_params = { # Defaults will be used for unspecified params here
+        current_mock_params = {
             "exitConvictionDropTrigger": 0.4,
-            "cnnPatternWeight": 1.0, # Default cnnPatternWeight
-            # strongBearishPatternThresholdExit will use default 0.5
-            # exitRulePatternScore will use default 0.7
+            "cnnPatternWeight": 1.0,
+            # strongPatternThreshold will use default 0.5 from get_param call
+            # exitRulePatternScore will use default 0.7 from get_param call
+            "minProfitForLowConfExit": 0.005, # Explicitly set for clarity, though could use default
+            "exitPatternConfThreshold": 0.5, # Explicitly set
+            "exitAISellIntentConfThreshold": 0.6 # Explicitly set
         }
         optimizer.params_manager.get_param = lambda key, strategy_id=None, default=None: current_mock_params.get(key, default)
 

--- a/core/params_manager.py
+++ b/core/params_manager.py
@@ -48,7 +48,8 @@ class ParamsManager:
                 "DUOAI_Strategy": {
                     "entryConvictionThreshold": 0.7,
                     "exitConvictionDropTrigger": 0.4,
-                    "cnnPatternWeight": 1.0, # NIEUW: Initiële waarde voor CNN-patroon gewicht
+                    "cnnPatternWeight": 1.0,
+                    "strongPatternThreshold": 0.5, # Default threshold for pattern strength
                     "preferredPairs": [],
                     "minimal_roi": {"0": 0.05, "30": 0.03, "60": 0.02, "120": 0.01},
                     "stoploss": -0.10,
@@ -182,6 +183,11 @@ if __name__ == "__main__":
         print(f"Standaard cnnPatternWeight voor {test_strategy_id}: {cnn_weight_default}")
         assert cnn_weight_default == 1.0
 
+        # Get strategy-specific parameter (strongPatternThreshold from default)
+        strong_thresh_default = params_manager.get_param("strongPatternThreshold", test_strategy_id)
+        print(f"Standaard strongPatternThreshold voor {test_strategy_id}: {strong_thresh_default}")
+        assert strong_thresh_default == 0.5
+
         # Get a parameter that only exists in default strategy for a different strategy_id (should fallback to None)
         cnn_weight_other_fallback = params_manager.get_param("cnnPatternWeight", other_strategy_id)
         print(f"Standaard cnnPatternWeight voor {other_strategy_id} (geen default, niet global): {cnn_weight_other_fallback}")
@@ -228,6 +234,10 @@ if __name__ == "__main__":
         # cnnPatternWeight for test_strategy_id was not explicitly set for test_strategy_id, so it should load default.
         print(f"Hergeladen cnnPatternWeight voor {test_strategy_id}: {reloaded_manager.get_param('cnnPatternWeight', test_strategy_id)}")
         assert reloaded_manager.get_param("cnnPatternWeight", test_strategy_id) == 1.0
+
+        # strongPatternThreshold for test_strategy_id was not explicitly set, should load default.
+        print(f"Hergeladen strongPatternThreshold voor {test_strategy_id}: {reloaded_manager.get_param('strongPatternThreshold', test_strategy_id)}")
+        assert reloaded_manager.get_param("strongPatternThreshold", test_strategy_id) == 0.5
 
         # Check the cnnPatternWeight for other_strategy_id after reload
         print(f"Hergeladen cnnPatternWeight voor {other_strategy_id}: {reloaded_manager.get_param('cnnPatternWeight', other_strategy_id)}")


### PR DESCRIPTION
…ht usage

This commit standardizes the use of `strongPatternThreshold` across entry and exit deciders and ensures `cnnPatternWeight` is correctly applied.

Changes include:

- `core/params_manager.py`:
  - Added `strongPatternThreshold: 0.5` to the default parameters for `DUOAI_Strategy`.
  - Verified `cnnPatternWeight: 1.0` was already present.
  - Updated tests to check for retrieval of both parameters.

- `core/entry_decider.py`:
  - Modified `should_enter` to fetch `strongPatternThreshold` from `ParamsManager` (default 0.5) instead of using `entry_conviction_threshold` for pattern strength evaluation.
  - Verified `cnnPatternWeight` is correctly fetched and applied to both CNN and rule-based pattern scores.
  - Updated tests to reflect the use of `strongPatternThreshold` and to test `cnnPatternWeight`'s impact.

- `core/exit_optimizer.py`:
  - Modified `should_exit` to use the common `strongPatternThreshold` (default 0.5) fetched from `ParamsManager` for evaluating bearish pattern strength, replacing the previous `strongBearishPatternThresholdExit` parameter.
  - Verified `cnnPatternWeight` and `exitRulePatternScore` are correctly fetched and applied to pattern scores.
  - Updated tests to reflect the use of the common `strongPatternThreshold` and test related logic.

This change improves consistency in how pattern strength is evaluated and configured across the application.