### PR TITLE
Refactor: Improve CNN pattern usage and parameter defaults

### DIFF
--- a/core/params_manager.py
+++ b/core/params_manager.py
@@ -50,6 +50,8 @@ class ParamsManager:
                     "exitConvictionDropTrigger": 0.4,
                     "cnnPatternWeight": 1.0, # NIEUW: Initiële waarde voor CNN-patroon gewicht
                     "strongPatternThreshold": 0.5, # Default threshold for strong patterns
+                    "entryRulePatternScore": 0.7, # NIEUW: Default score for a detected rule-based entry pattern
+                    "exitRulePatternScore": 0.7,  # NIEUW: Default score for a detected rule-based exit pattern
                     "preferredPairs": [],
                     "minimal_roi": {"0": 0.05, "30": 0.03, "60": 0.02, "120": 0.01},
                     "stoploss": -0.10,
@@ -187,6 +189,14 @@ if __name__ == "__main__":
         print(f"Standaard strongPatternThreshold voor {test_strategy_id}: {strong_pattern_threshold}")
         assert strong_pattern_threshold == 0.5
 
+        entry_rule_score = params_manager.get_param("entryRulePatternScore", test_strategy_id)
+        print(f"Standaard entryRulePatternScore voor {test_strategy_id}: {entry_rule_score}")
+        assert entry_rule_score == 0.7
+
+        exit_rule_score = params_manager.get_param("exitRulePatternScore", test_strategy_id)
+        print(f"Standaard exitRulePatternScore voor {test_strategy_id}: {exit_rule_score}")
+        assert exit_rule_score == 0.7
+
         # Get a parameter that only exists in default strategy for a different strategy_id (should fallback to None)
         cnn_weight_other_fallback = params_manager.get_param("cnnPatternWeight", other_strategy_id)
         print(f"Standaard cnnPatternWeight voor {other_strategy_id} (geen default, niet global): {cnn_weight_other_fallback}")
@@ -241,6 +251,14 @@ if __name__ == "__main__":
         reloaded_strong_threshold = reloaded_manager.get_param('strongPatternThreshold', test_strategy_id)
         print(f"Hergeladen strongPatternThreshold voor {test_strategy_id}: {reloaded_strong_threshold}")
         assert reloaded_strong_threshold == 0.5
+
+        reloaded_entry_rule_score = reloaded_manager.get_param('entryRulePatternScore', test_strategy_id)
+        print(f"Hergeladen entryRulePatternScore voor {test_strategy_id}: {reloaded_entry_rule_score}")
+        assert reloaded_entry_rule_score == 0.7
+
+        reloaded_exit_rule_score = reloaded_manager.get_param('exitRulePatternScore', test_strategy_id)
+        print(f"Hergeladen exitRulePatternScore voor {test_strategy_id}: {reloaded_exit_rule_score}")
+        assert reloaded_exit_rule_score == 0.7
 
         print(f"Hergeladen ROI voor {test_strategy_id}: {reloaded_manager.get_param('minimal_roi', test_strategy_id)}")
         assert reloaded_manager.get_param("minimal_roi", test_strategy_id) == new_roi


### PR DESCRIPTION
This commit addresses inconsistencies in CNN pattern usage and ensures default values for rule pattern scores.

1.  **`core/exit_optimizer.py`**:
    *   Modified `should_exit` to use `no_bullFlag_score` (obtained from
        `cnn_patterns.py`) as the CNN-derived bearish signal. This resolves
        a mismatch where `exit_optimizer.py` previously expected a specific
        bearish pattern score (e.g., `bearishEngulfing_score`) from the CNN
        module, which `cnn_patterns.py` does not provide.
    *   Updated tests in `run_test_exit_optimizer` to align with this change,
        ensuring mocks provide `no_bullFlag_score` and assertions are correct.

2.  **`core/params_manager.py`**:
    *   Added default values for `entryRulePatternScore` (0.7) and
        `exitRulePatternScore` (0.7) to the `DUOAI_Strategy` in
        `_get_default_params`.
    *   Updated `run_test_params_manager` to include assertions for these
        new default parameters, verifying both initial load and reloading.

These changes enhance the consistency of pattern processing and parameter management within the application.