### PR TITLE
feat: Enhance PreTrainer with multiple new capabilities

### DIFF
--- a/core/params_manager.py
+++ b/core/params_manager.py
@@ -48,6 +48,7 @@ class ParamsManager:
                 "data_fetch_pairs": ["ETH/USDT", "ETH/BTC", "LSK/BTC", "ZEN/BTC", "ETH/EUR"],
                 "data_fetch_timeframes": ["1h", "4h"],
                 "patterns_to_train": ["bullFlag", "bearishEngulfing"],
+                "gold_standard_data_path": "", # Path to gold standard data CSVs
                 "pattern_labeling_configs": {
                     "bullFlag": {
                         "future_N_candles": 20,
@@ -97,7 +98,16 @@ class ParamsManager:
                 "backtest_hold_duration_candles": 20,
                 "backtest_initial_capital": 1000.0,
                 "backtest_stake_pct_capital": 0.1,
-                "default_strategy_id": "DefaultPipelineRunStrategy" # Added default strategy ID
+                "default_strategy_id": "DefaultPipelineRunStrategy", # Added default strategy ID
+
+                # Hyperparameter Optimization (HPO) settings
+                "perform_hyperparameter_optimization": False, # Whether to run HPO
+                "hpo_num_trials": 20, # Number of HPO trials to run (e.g., 10-50)
+                "hpo_sampler": "TPE",   # Optuna sampler: 'TPE', 'Random'
+                "hpo_pruner": "Median", # Optuna pruner: 'Median', 'None'
+                "hpo_metric_to_optimize": "val_loss", # Metric to optimize: 'val_loss', 'val_accuracy', 'val_f1', 'val_auc'
+                "hpo_direction_to_optimize": "minimize", # Direction: 'minimize' for loss, 'maximize' for acc/f1/auc
+                "regimes_to_train": ["all"] # List of market regimes to train models for (e.g., ["bull", "bear", "all"])
             },
             "strategies": {
                 "DUOAI_Strategy": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-dotenv
 requests
 pytest
 pytest-asyncio
+optuna>=3.0.0


### PR DESCRIPTION
This commit introduces several significant enhancements to the `core/pre_trainer.py` module:

1.  **Bearish Pattern Labeling Clarification:**
    *   Reviewed and confirmed the correctness of the labeling logic for bearish patterns (`bearishEngulfing`).
    *   Added inline comments to `prepare_training_data` to clarify how `profit_threshold_pct` (representing a percentage decrease) and `loss_threshold_pct` (representing a percentage increase, acting as a stop-loss) are interpreted, especially the use of `abs(loss_thresh)`.

2.  **Gold Standard Dataset Loading:**
    *   Added functionality to load and use hand-labeled "gold standard" datasets.
    *   `ParamsManager` now includes `gold_standard_data_path` to specify the directory for these CSV files.
    *   A new `_load_gold_standard_data` method reads these files (expected format: `symbol_timeframe_pattern_gold.csv` with OHLCV and `gold_label`).
    *   `prepare_training_data` now prioritizes labels from gold standard data if available, falling back to automatic labeling for other data points.

3.  **Hyperparameter Optimization (HPO) with Optuna:**
    *   Integrated Optuna for hyperparameter optimization of CNN models.
    *   Added `optuna` to `requirements.txt`.
    *   `ParamsManager` now includes parameters to control HPO (`perform_hyperparameter_optimization`, `hpo_num_trials`, `hpo_sampler`, `hpo_pruner`, `hpo_metric_to_optimize`, `hpo_direction_to_optimize`, `hpo_timeout_seconds`).
    *   `train_ai_models` can now run an Optuna study to find optimal architectural and training hyperparameters (e.g., learning rate, batch size, number of conv layers, filters, kernel sizes, dropout).
    *   The best parameters found by HPO are used for the final model training.
    *   Model and scaler filenames are appended with `_hpo` if HPO is performed.

4.  **Market Regime-Specific Training:**
    *   Extended the pipeline to train separate models for different market regimes (e.g., bull, bear, sideways).
    *   `ParamsManager` now includes `regimes_to_train` (e.g., `["all", "bull"]`).
    *   `fetch_historical_data` now returns a dictionary of DataFrames, keyed by regime name (plus an "all" key). Data is sourced based on `market_regimes.json`.
    *   `run_pretraining_pipeline` iterates through the specified regimes, training a model for each.
    *   Model and scaler filenames, as well as log entries, now include the regime name.
    *   Backtesting currently defaults to using models trained on the "all" regime data.

5.  **Testing and Validation:**
    *   The main integration test (`run_test_pre_trainer` in `core/pre_trainer.py`) has been significantly updated to:
        *   Generate dummy gold standard CSV files.
        *   Generate a dummy `market_regimes.json`.
        *   Configure and run the pre-training pipeline with gold standard loading, HPO (for a few trials), and regime-specific training enabled.
        *   Validate the creation of appropriately named model/scaler files (including `_hpo` and regime suffixes).
        *   Validate entries in the pre-train log file for HPO and regimes.

These enhancements provide greater flexibility and sophistication in the model pre-training process.