### PR TITLE
Refactor AIActivationEngine and ReflectieLus integration

### DIFF
--- a/core/ai_activation_engine.py
+++ b/core/ai_activation_engine.py
@@ -14,8 +14,11 @@ from core.gpt_reflector import GPTReflector
 from core.grok_reflector import GrokReflector
 from core.prompt_builder import PromptBuilder
 from core.cnn_patterns import CNNPatterns
+from core.reflectie_lus import ReflectieLus
 # ReflectieLus, BiasReflector, ConfidenceEngine, StrategyManager
 # will be passed via dependency injection to activate_ai to avoid circular imports.
+
+from core.grok_sentiment_fetcher import GrokSentimentFetcher
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -32,16 +35,27 @@ class AIActivationEngine:
     Vertaald en geoptimaliseerd van aiActivationEngine.js.
     """
 
-    def __init__(self):
+    def __init__(self, reflectie_lus_instance: ReflectieLus):
         try:
             self.prompt_builder = PromptBuilder()
         except Exception as e:
             logger.error(f"Failed to initialize PromptBuilder in AIActivationEngine: {e}")
             self.prompt_builder = None # Fallback
 
+        self.reflectie_lus_instance = reflectie_lus_instance
+        if self.reflectie_lus_instance is None:
+            logger.error("ReflectieLus instance not provided to AIActivationEngine. AI activation will not work correctly.")
+            # Optionally raise an error: raise ValueError("ReflectieLus instance is required")
+
         self.gpt_reflector = GPTReflector()
         self.grok_reflector = GrokReflector()
         self.cnn_patterns_detector = CNNPatterns()
+
+        try:
+            self.grok_sentiment_fetcher = GrokSentimentFetcher()
+        except ValueError as e:
+            logger.error(f"Failed to initialize GrokSentimentFetcher: {e}. Sentiment analysis will be disabled.")
+            self.grok_sentiment_fetcher = None
 
         self.last_reflection_timestamps: Dict[str, float] = {} # Per token
         logger.info("AIActivationEngine geïnitialiseerd.")
@@ -52,11 +66,25 @@ class AIActivationEngine:
     def _update_last_reflection_timestamp(self, token: str):
         self.last_reflection_timestamps[token] = datetime.now().timestamp() * 1000
 
-    def _should_trigger_ai(self, trigger_data: Dict[str, Any], mode: str = 'live') -> bool:
+    async def _should_trigger_ai(self, trigger_data: Dict[str, Any], symbol: str, mode: str = 'live') -> bool:
         """
         Bepaalt of de AI-reflectie moet worden getriggerd op basis van verschillende factoren.
         """
         score = 0
+
+        if self.grok_sentiment_fetcher:
+            try:
+                sentiment_items = await self.grok_sentiment_fetcher.fetch_live_search_data(symbol)
+                if sentiment_items:
+                    logger.info(f"Sentiment items found for {symbol}: {len(sentiment_items)}. Incrementing trigger score.")
+                    score += 1 # Increment score by 1 if sentiment items are found
+                else:
+                    logger.info(f"No sentiment items found for {symbol}.")
+            except Exception as e:
+                logger.error(f"Error fetching sentiment for {symbol}: {e}")
+        else:
+            logger.warning("GrokSentimentFetcher not available, skipping sentiment check in _should_trigger_ai.")
+
         pattern_score = trigger_data.get('patternScore', 0.0)
         volume_spike = trigger_data.get('volumeSpike', False)
         learned_confidence = trigger_data.get('learned_confidence', 0.5)
@@ -160,63 +188,63 @@ class AIActivationEngine:
             "profit_metric": trade_context.get('profit_pct', 0.0) if trade_context else 0.0
         }
 
-        if not self._should_trigger_ai(trigger_data, mode):
+        if not await self._should_trigger_ai(trigger_data, token, mode):
             logger.info(f"[AI-ACTIVATION] AI niet getriggerd voor {token} ({trigger_type}).")
             return None
 
-        prompt = await self.prompt_builder.generate_prompt_with_data(
-            candles_by_timeframe=candles_by_timeframe,
-            symbol=token,
-            prompt_type='comprehensive_analysis',
-            current_bias=current_bias,
-            current_confidence=learned_confidence,
-            trade_context=trade_context,
-            trigger_type=trigger_type,
-            pattern_data=pattern_data
-        )
-        if not prompt:
-            logger.warning(f"[AI-ACTIVATION] Geen prompt gegenereerd voor {token}.")
+        if self.reflectie_lus_instance is None:
+            logger.error("ReflectieLus instance is not available in AIActivationEngine. Cannot process reflection.")
             return None
 
-        gpt_result = await self.gpt_reflector.ask_ai(prompt, context={"token": token, "strategy_id": strategy_id, "trigger_type": trigger_type, **(trade_context or {})})
-        grok_result = await self.grok_reflector.ask_grok(prompt, context={"token": token, "strategy_id": strategy_id, "trigger_type": trigger_type, **(trade_context or {})})
-
-        gpt_confidence = gpt_result.get('confidence', 0.0) or 0.0
-        grok_confidence = grok_result.get('confidence', 0.0) or 0.0
-
-        num_valid_confidences = sum(1 for c in [gpt_confidence, grok_confidence] if isinstance(c, (float,int)) and c > 0)
-        combined_ai_confidence = ((gpt_confidence + grok_confidence) / num_valid_confidences) if num_valid_confidences > 0 else 0.0
-
-        gpt_reported_bias = gpt_result.get('bias', current_bias)
-        grok_reported_bias = grok_result.get('bias', current_bias)
-        combined_ai_reported_bias = ((gpt_reported_bias or current_bias) + (grok_reported_bias or current_bias)) / 2.0
-
-        reflectie_log_entry = {
-            "timestamp": datetime.now().isoformat(),
-            "trigger_type": trigger_type,
-            "token": token,
-            "strategyId": strategy_id,
-            "pattern_data": pattern_data,
-            "trigger_decision_data": trigger_data,
-            "prompt_generated": prompt,
-            "gpt_response": gpt_result,
-            "grok_response": grok_result,
-            "trade_context": trade_context,
-            "learned_bias_at_trigger": current_bias,
-            "learned_confidence_at_trigger": learned_confidence,
-            "combined_ai_confidence": combined_ai_confidence,
-            "combined_ai_reported_bias": combined_ai_reported_bias,
-            "mode": mode
+        # Prepare trade_context for ReflectieLus
+        # It already contains trade_context passed to activate_ai.
+        # We need to add trigger_type and pattern_data.
+        extended_trade_context = {
+            **(trade_context or {}),
+            "trigger_type": trigger_type, # Pass the original trigger_type
+            # pattern_data is already computed and available in this scope
         }
 
-        if mode not in ['pretrain', 'backtest_simulation']:
-            await self._log_reflection_entry(reflectie_log_entry)
-            self._update_last_reflection_timestamp(token)
-            logger.info(f"[AI-ACTIVATION] ✅ Reflectie gegenereerd en gelogd voor {token} ({trigger_type}).")
+        logger.info(f"[AI-ACTIVATION] Delegating to ReflectieLus for {token} ({trigger_type}).")
 
-        return reflectie_log_entry
+        # The prompt_type for ReflectieLus will be handled in Step 3 of the main plan.
+        # For now, we assume ReflectieLus.process_reflection_cycle will take pattern_data.
+        # We will pass 'comprehensive_analysis' as prompt_type, and pattern_data.
+        # This requires ReflectieLus.process_reflection_cycle to be updated in the next step.
+        reflection_result = await self.reflectie_lus_instance.process_reflection_cycle(
+            symbol=token,
+            candles_by_timeframe=candles_by_timeframe,
+            strategy_id=strategy_id,
+            trade_context=extended_trade_context, # Contains original trade_context, trigger_type
+            current_bias=current_bias, # Calculated in activate_ai
+            current_confidence=learned_confidence, # Calculated in activate_ai
+            mode=mode,
+            # These are new parameters to be added to ReflectieLus.process_reflection_cycle in plan step 3
+            prompt_type='comprehensive_analysis',
+            pattern_data=pattern_data
+        )
+
+        # The original activate_ai returned reflectie_log_entry.
+        # process_reflection_cycle returns a dictionary which might be different.
+        # We return what ReflectieLus returns.
+        return reflection_result
 
 if __name__ == "__main__":
+    # Adjust __main__ to pass ReflectieLus instance
+    from core.reflectie_lus import ReflectieLus # Ensure import if not already at top for __main__
+    # Mock or initialize ReflectieLus as needed for testing
+    # For example, a simple mock if ReflectieLus has complex dependencies:
+    class MockReflectieLus:
+        async def process_reflection_cycle(self, **kwargs):
+            logger.info(f"MockReflectieLus.process_reflection_cycle called with {kwargs.get('symbol')}, {kwargs.get('prompt_type')}")
+            # Return a structure similar to what ReflectieLus would return if needed for testing continuity
+            return {"reflection_summary": "Mock reflection processed", "details": kwargs}
+
+    mock_reflectie_lus_instance = MockReflectieLus()
+    # Pass it to the engine
+    # engine = AIActivationEngine() # OLD
+    # engine = AIActivationEngine(reflectie_lus_instance=mock_reflectie_lus_instance) # NEW - this will be adjusted in the main block below.
+
     dotenv_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '.env')
     dotenv.load_dotenv(dotenv_path)
 
@@ -246,7 +274,24 @@ if __name__ == "__main__":
         return df
 
     async def run_test_ai_activation_engine():
-        engine = AIActivationEngine()
+        # Moved reflectie_lus instance creation inside the async test function
+        # to ensure it's created within the same async context if needed,
+        # or just for neatness.
+        class MockReflectieLusForTest: # Renamed to avoid conflict if MockReflectieLus is defined globally
+            async def process_reflection_cycle(self, **kwargs):
+                logger.info(f"MockReflectieLusForTest.process_reflection_cycle called for {kwargs.get('symbol')} with prompt_type {kwargs.get('prompt_type')}")
+                # Simulate returning a reflection log entry structure
+                return {
+                    "timestamp": datetime.now().isoformat(),
+                    "token": kwargs.get('symbol'),
+                    "strategyId": kwargs.get('strategy_id'),
+                    "prompt_type": kwargs.get('prompt_type'),
+                    "summary": "Mocked reflection cycle completed.",
+                    "mode": kwargs.get('mode'),
+                    "pattern_data_used": kwargs.get('pattern_data') is not None
+                }
+        mock_reflectie_lus = MockReflectieLusForTest()
+        engine = AIActivationEngine(reflectie_lus_instance=mock_reflectie_lus)
         test_token = "ETH/USDT"
         test_strategy_id = "DUOAI_Strategy"
 
@@ -271,14 +316,21 @@ if __name__ == "__main__":
         mock_bias_reflector = MockBiasReflector()
         mock_confidence_engine = MockConfidenceEngine()
 
-        if engine.prompt_builder is None:
-            class MockPromptBuilder:
+        # PromptBuilder mock might still be needed if CNNPatterns or other parts of AIActivationEngine use it.
+        # If PromptBuilder is solely for ReflectieLus now, this specific mock for AIActivationEngine might be removable.
+        # However, CNNPatterns is initialized in AIActivationEngine and might use PromptBuilder.
+        # Let's assume it's still potentially needed for other internal mechanics or future features.
+        if engine.prompt_builder is None: # This check is good practice.
+            class MockPromptBuilder: # Ensure this mock is sufficient for any remaining uses.
                 async def generate_prompt_with_data(self, **kwargs):
-                    return f"Mock prompt for {kwargs.get('symbol')} - {kwargs.get('prompt_type')}"
+                    # This mock might not be hit if PromptBuilder is only used by the removed logic.
+                    logger.info(f"MockPromptBuilder.generate_prompt_with_data called for {kwargs.get('symbol')}")
+                    return f"Fallback mock prompt for {kwargs.get('symbol')} - {kwargs.get('prompt_type')}"
             engine.prompt_builder = MockPromptBuilder()
 
+
         print("\n--- Test AIActivationEngine ---")
-        print("\nActiveren AI voor een 'entry_signal' trigger...")
+        print("\nActiveren AI voor een 'entry_signal' trigger (delegated to ReflectieLus)...")
         entry_reflection = await engine.activate_ai(
             trigger_type='entry_signal',
             token=test_token,
@@ -290,11 +342,11 @@ if __name__ == "__main__":
             confidence_engine_instance=mock_confidence_engine
         )
         if entry_reflection:
-            print("\nResultaat Entry Signaal Reflectie:", json.dumps(entry_reflection, indent=2, default=str))
+            print("\nResultaat Entry Signaal Reflectie (via ReflectieLus):", json.dumps(entry_reflection, indent=2, default=str))
         else:
-            print("Entry Signaal Reflectie niet getriggerd / geen resultaat.")
+            print("Entry Signaal Reflectie (via ReflectieLus) niet getriggerd / geen resultaat.")
 
-        print("\nActiveren AI voor een 'trade_closed' trigger...")
+        print("\nActiveren AI voor een 'trade_closed' trigger (delegated to ReflectieLus)...")
         exit_reflection = await engine.activate_ai(
             trigger_type='trade_closed',
             token=test_token,
@@ -306,10 +358,63 @@ if __name__ == "__main__":
             confidence_engine_instance=mock_confidence_engine
         )
         if exit_reflection:
-            print("\nResultaat Trade Closed Reflectie:", json.dumps(exit_reflection, indent=2, default=str))
+            print("\nResultaat Trade Closed Reflectie (via ReflectieLus):", json.dumps(exit_reflection, indent=2, default=str))
         else:
-            print("Trade Closed Reflectie niet getriggerd / geen resultaat.")
+            print("Trade Closed Reflectie (via ReflectieLus) niet getriggerd / geen resultaat.")
 
-        print(f"Check {REFLECTIE_LOG_FILE} voor gelogde reflecties.")
+        # Logging is now handled by ReflectieLus, so REFLECTIE_LOG_FILE check here might be redundant
+        # or should point to wherever ReflectieLus logs, if different.
+        # For now, let's assume ReflectieLus uses the same logging mechanism or path.
+        print(f"Check logs for ReflectieLus processing details (potentially {REFLECTIE_LOG_FILE} if used by ReflectieLus).")
+
+        # Call the new test function
+        await test_should_trigger_ai_logic(engine)
+
+    # Add to imports in __main__ or at the top of the file if used more broadly
+    from unittest.mock import patch, AsyncMock
+
+    async def test_should_trigger_ai_logic(engine_instance: AIActivationEngine):
+        logger.info("\n--- Test _should_trigger_ai Logic ---")
+
+        # Test case 1: Sentiment data found
+        with patch.object(engine_instance.grok_sentiment_fetcher, 'fetch_live_search_data', new_callable=AsyncMock, return_value=[{"item": "data"}]):
+            trigger_data_sentiment = {"patternScore": 0.5, "volumeSpike": False, "learned_confidence": 0.7, "time_since_last_reflection": 0, "profit_metric": 0.0}
+            # Expected score: 0 (base) + 1 (sentiment) = 1. Confidence > 0.6 no points. time_since_last no points, profit_metric no points.
+            # Threshold for confidence 0.7 is 3. So, 1 < 3, should be False.
+            # Let's make learned_confidence low to trigger
+            trigger_data_sentiment_low_conf = {"patternScore": 0.5, "volumeSpike": False, "learned_confidence": 0.3, "time_since_last_reflection": 0, "profit_metric": 0.0}
+            # Score: 1 (sentiment) + 2 (low confidence) = 3. Threshold for conf 0.3 is 2. 3 >= 2, should be True.
+            result_sentiment = await engine_instance._should_trigger_ai(trigger_data_sentiment_low_conf, "TEST/TOKEN", "live")
+            assert result_sentiment is True, "Should trigger with sentiment and low confidence"
+            logger.info(f"Test with sentiment data (low conf): Triggered = {result_sentiment} (Expected True)")
+
+        # Test case 2: No sentiment data
+        with patch.object(engine_instance.grok_sentiment_fetcher, 'fetch_live_search_data', new_callable=AsyncMock, return_value=[]):
+            trigger_data_no_sentiment_low_conf = {"patternScore": 0.5, "volumeSpike": False, "learned_confidence": 0.3, "time_since_last_reflection": 0, "profit_metric": 0.0}
+            # Score: 0 (no sentiment) + 2 (low confidence) = 2. Threshold for conf 0.3 is 2. 2 >= 2, should be True.
+            result_no_sentiment = await engine_instance._should_trigger_ai(trigger_data_no_sentiment_low_conf, "TEST/TOKEN", "live")
+            assert result_no_sentiment is True, "Should trigger with low confidence even without sentiment" # This depends on threshold logic
+            logger.info(f"Test with no sentiment data (low conf): Triggered = {result_no_sentiment} (Expected True)")
+
+            # Test case 2b: No sentiment, high confidence (should not trigger)
+            trigger_data_no_sentiment_high_conf = {"patternScore": 0.1, "volumeSpike": False, "learned_confidence": 0.8, "time_since_last_reflection": 0, "profit_metric": 0.0}
+            # Score: 0 (no sentiment). Threshold for conf 0.8 is 3. 0 < 3, should be False.
+            result_no_sentiment_high_conf = await engine_instance._should_trigger_ai(trigger_data_no_sentiment_high_conf, "TEST/TOKEN", "live")
+            assert result_no_sentiment_high_conf is False, "Should NOT trigger with no sentiment and high confidence and low pattern score"
+            logger.info(f"Test with no sentiment data (high conf, low pattern): Triggered = {result_no_sentiment_high_conf} (Expected False)")
+
+        # Test case 3: GrokSentimentFetcher is None (simulating initialization failure)
+        # Ensure GrokSentimentFetcher might be None in __init__ for this test to be fully valid.
+        # It is, due to the try-except block.
+        original_fetcher = engine_instance.grok_sentiment_fetcher
+        engine_instance.grok_sentiment_fetcher = None
+        trigger_data_no_fetcher_low_conf = {"patternScore": 0.5, "volumeSpike": False, "learned_confidence": 0.3, "time_since_last_reflection": 0, "profit_metric": 0.0}
+        # Score: 0 (no sentiment fetcher) + 2 (low confidence) = 2. Threshold for conf 0.3 is 2. 2 >= 2, should be True.
+        result_no_fetcher = await engine_instance._should_trigger_ai(trigger_data_no_fetcher_low_conf, "TEST/TOKEN", "live")
+        assert result_no_fetcher is True, "Should trigger with low confidence even if fetcher is None"
+        logger.info(f"Test with GrokSentimentFetcher as None (low conf): Triggered = {result_no_fetcher} (Expected True)")
+        engine_instance.grok_sentiment_fetcher = original_fetcher # Restore
+
+        logger.info("--- _should_trigger_ai Logic Test Complete ---")
 
     asyncio.run(run_test_ai_activation_engine())

--- a/core/reflectie_lus.py
+++ b/core/reflectie_lus.py
@@ -132,7 +132,9 @@ class ReflectieLus:
         trade_context: Optional[Dict[str, Any]] = None, # Context van de trade (entry/exit)
         current_bias: float = 0.5, # Huidige bias van de strategie
         current_confidence: float = 0.5, # Huidige confidence van de strategie
-        mode: str = 'live' # 'live', 'dry_run', 'backtest', 'pretrain'
+        mode: str = 'live', # 'live', 'dry_run', 'backtest', 'pretrain'
+        prompt_type: str = 'marketAnalysis',
+        pattern_data: Optional[Dict[str, Any]] = None
     ) -> Optional[Dict[str, Any]]:
         """
         Verwerkt een enkele reflectiecyclus voor een gegeven symbool.
@@ -141,7 +143,7 @@ class ReflectieLus:
         if trade_context is None:
             trade_context = {}
 
-        logger.info(f"[ReflectieCyclus] Starten reflectiecyclus voor {symbol} ({strategy_id}) in mode: {mode}")
+        logger.info(f"[ReflectieCyclus] Starten reflectiecyclus voor {symbol} ({strategy_id}) in mode: {mode} met prompt type: {prompt_type}")
 
         # 1. Gegevensverzameling
         # Freqtrade zal de DataFrames van candles_by_timeframe leveren
@@ -168,9 +170,11 @@ class ReflectieLus:
             prompt = await self.prompt_builder.generate_prompt_with_data(
                 candles_by_timeframe=candles_by_timeframe,
                 symbol=symbol,
-                prompt_type='marketAnalysis',
+                prompt_type=prompt_type, # Use the passed prompt_type
                 current_bias=current_bias,
-                current_confidence=current_confidence
+                current_confidence=current_confidence,
+                trade_context=trade_context, # Pass the full trade_context
+                pattern_data=pattern_data # Pass the received pattern_data
             )
         except AttributeError as e:
             logger.error(f"PromptBuilder of methode niet gevonden: {e}. Implementeer PromptBuilder eerst.")
@@ -422,7 +426,9 @@ if __name__ == "__main__":
             trade_context=mock_trade_context,
             current_bias=0.6,
             current_confidence=0.7,
-            mode='backtest'
+            mode='backtest',
+            prompt_type='comprehensive_analysis', # Added
+            pattern_data=None # Added, or use mock_pattern_data
         )
         print("\nResultaat van directe reflectiecyclus:")
         # Use default=str to handle any non-serializable objects like datetime


### PR DESCRIPTION
This commit addresses two main requirements:

1.  Extended `AIActivationEngine._should_trigger_ai` to incorporate external events, specifically sentiment data from `GrokSentimentFetcher`, into its trigger decision logic.

2.  Refactored the interaction between `AIActivationEngine` and `ReflectieLus` to centralize reflection logging and processing within `ReflectieLus`.
    *   `AIActivationEngine` now depends on an instance of `ReflectieLus`.
    *   When AI activation is triggered, `AIActivationEngine` delegates the reflection process (including prompt generation, AI model querying, and logging) to `ReflectieLus.process_reflection_cycle`.
    *   Duplicate logging functionality was removed from `AIActivationEngine`.
    *   `ReflectieLus.process_reflection_cycle` was updated to accept `prompt_type` and `pattern_data` to ensure consistent behavior when called from `AIActivationEngine`.

The `__main__` test blocks in both modules have been updated to reflect these changes, and specific unit tests were added to `AIActivationEngine` to verify the new sentiment-aware trigger logic.