### PR TITLE
Refactor: Use constructor-initialized CNNPatterns in PreTrainer

### DIFF
--- a/core/pre_trainer.py
+++ b/core/pre_trainer.py
@@ -433,10 +433,7 @@ class PreTrainer:
             return dataframe
 
         # Ensure technical indicators are calculated first (already seems to be the case)
-        if not hasattr(self, 'cnn_pattern_detector'):
-            from core.cnn_patterns import CNNPatterns
-            self.cnn_pattern_detector = CNNPatterns()
-            logger.info("CNNPatterns detector geïnitialiseerd in prepare_training_data.")
+        # self.cnn_pattern_detector is now initialized in the constructor
         if 'rsi' not in dataframe.columns: dataframe['rsi'] = ta.RSI(dataframe)
         if 'macd' not in dataframe.columns:
             macd_df = ta.MACD(dataframe)


### PR DESCRIPTION
I've removed redundant initialization of `CNNPatterns` within the `prepare_training_data` method of the `PreTrainer` class.

The `PreTrainer` class now consistently uses the `self.cnn_pattern_detector` (an instance of `CNNPatterns`) that is initialized in its constructor. This avoids unnecessary re-instantiation and ensures a single, consistent `CNNPatterns` object is used throughout the `PreTrainer`'s lifecycle, including within `prepare_training_data` and by the `Backtester` instance.