### PR TITLE
Refactor: Remove redundant AI trigger logic from ReflectieLus

### DIFF
--- a/core/reflectie_lus.py
+++ b/core/reflectie_lus.py
@@ -85,13 +85,6 @@ class ReflectieLus:
             logger.warning(f'[StoreReflection] Fout bij opslaan: {e}')
             return False
 
-    def _get_time_since_last_reflection(self, token: str) -> float:
-        """
-        Geeft de tijd (in milliseconden) sinds de laatste reflectie voor een token.
-        Vertaald van getTimeSinceLast in aiActivationEngine.js.
-        """
-        return (datetime.now().timestamp() * 1000) - self.last_reflection_timestamps.get(token, 0)
-
     def _update_last_reflection_timestamp(self, token: str):
         """
         Update het timestamp van de laatste reflectie voor een token.


### PR DESCRIPTION
The AIActivationEngine is now solely responsible for deciding if the AI should be triggered. This commit removes legacy trigger-related code from core/reflectie_lus.py.

Changes:
- Removed the `_get_time_since_last_reflection` method from `ReflectieLus` as it was no longer used.
- Confirmed that the `_should_trigger_ai` method was already absent from `ReflectieLus`.
- Confirmed that `process_reflection_cycle` in `ReflectieLus` no longer contains any internal trigger checks and relies on `AIActivationEngine` for activation.