### PR TITLE
Refactor: Clarify Grok API configurations and verify pair whitelist.

### DIFF
--- a/core/grok_reflector.py
+++ b/core/grok_reflector.py
@@ -14,6 +14,9 @@ logger.setLevel(logging.INFO)
 
 GROK_API_KEY = os.getenv('GROK_API_KEY')
 GROK_MODEL = os.getenv('GROK_MODEL', 'grok-1')
+# Note: For 'live data feat' (e.g., real-time social media feed analysis via GrokSentimentFetcher),
+# GROK_MODEL should be set to 'grok-3' in the .env file.
+# This feature relies on Grok 3's advanced capabilities for processing live data.
 # Corrected ENDPOINT definition to remove markdown link
 ENDPOINT = os.getenv('GROK_API_URL', 'https://api.x.ai/v1/chat/completions') # Voorbeeldendpoint
 

--- a/core/grok_sentiment_fetcher.py
+++ b/core/grok_sentiment_fetcher.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 GROK_API_KEY = os.getenv('GROK_API_KEY')
-LIVE_SEARCH_API_URL = os.getenv('GROK_LIVE_SEARCH_API_URL', 'https://api.x.ai/v1/live-search') # Hypothetisch endpoint
+LIVE_SEARCH_API_URL = os.getenv('GROK_LIVE_SEARCH_API_URL', 'https://api.x.ai/v1/live-search') # TODO: Update with official endpoint when available. This is a hypothetical endpoint.
 
 # Padconfiguratie voor cache
 # __file__ is de huidige bestandsnaam. os.path.dirname haalt de map op.


### PR DESCRIPTION
This commit addresses several documentation and configuration aspects:

- I verified that the required trading pairs (ZEN/BTC, LSK/BTC, ETH/BTC, ETH/EUR) are already present in `config/config.json`'s `pair_whitelist`. No changes were made to the whitelist.
- I confirmed that `strategies/DUOAI_Strategy.py` correctly loads the `pair_whitelist` dynamically from the Freqtrade configuration and does not use a hardcoded list for generating `informative_pairs`. No changes were made to the strategy file.
- I added a TODO comment to `core/grok_sentiment_fetcher.py` for the `GROK_LIVE_SEARCH_API_URL` to emphasize its hypothetical nature and the need for an official endpoint.
- I added comments to `core/grok_reflector.py` to specify that the 'live data feat' (social media analysis) requires `GROK_MODEL` to be set to `grok-3` in the .env file, highlighting its dependency on Grok 3's capabilities.