### PR TITLE
Integrate AIActivationEngine and complete learning cycle feedback

### DIFF
--- a/core/ai_activation_engine.py
+++ b/core/ai_activation_engine.py
@@ -254,9 +254,10 @@ class AIActivationEngine:
             current_bias=current_bias, # Calculated in activate_ai
             current_confidence=learned_confidence, # Calculated in activate_ai
             mode=mode,
-            # These are new parameters to be added to ReflectieLus.process_reflection_cycle in plan step 3
             prompt_type=prompt_type, # Use the determined prompt_type
-            pattern_data=pattern_data
+            pattern_data=pattern_data,
+            bias_reflector_instance=bias_reflector_instance, # Pass through
+            confidence_engine_instance=confidence_engine_instance # Pass through
         )
 
         # The original activate_ai returned reflectie_log_entry.


### PR DESCRIPTION
Key changes:
- Integrated AIActivationEngine into DUOAI_Strategy: The strategy now calls AIActivationEngine to initiate the reflection process after a trade closes.
- Verified PromptBuilder data flow: Ensured PromptBuilder receives CNN pattern data and social sentiment via AIActivationEngine and ReflectieLus.
- Implemented learning cycle feedback: ReflectieLus now calls update_bias on BiasReflector and update_confidence on ConfidenceEngine, using the AI's reflection outputs (combined_bias, combined_confidence) and trade profit/loss percentages.

This addresses the issue by ensuring the AI components are correctly wired, the prompt system has full data, and the bias/confidence mechanisms are updated based on reflection outcomes, enabling the self-learning aspect of the bot.