### PR TITLE
Refactor: Centralize indicator definitions in DUOAI_Strategy

### DIFF
--- a/core/cnn_patterns.py
+++ b/core/cnn_patterns.py
@@ -153,27 +153,20 @@ class CNNPatterns:
             })
             base_ohlcv_df.index = dataframe.index # Preserve original index
 
-            # 2. Generate TA-Lib candlestick pattern features (conditionally)
-            candlestick_features_df = pd.DataFrame(index=dataframe.index) # Default to empty
-            try:
-                # talib is imported at the top of the file. If that failed, this won't run.
-                # If pandas_ta is imported as ta, _get_talib_candlestick_patterns (soon to be _get_candlestick_patterns)
-                # will use it.
-                candlestick_features_df = _get_talib_candlestick_patterns(base_ohlcv_df)
-                logger.debug(f"Candlestick features generated. Shape: {candlestick_features_df.shape}")
-            # Removed ImportError for talib, as we are moving away from it.
-            # The function _get_talib_candlestick_patterns itself will handle issues with pandas_ta.
-            except Exception as e_pattern_gen: # Catch other potential errors
-                logger.error(f"Error generating candlestick patterns: {e_pattern_gen}. Proceeding without them.", exc_info=True)
-
+            # 2. Candlestick patterns are now expected to be in `dataframe` (copied to `df_processed`)
+            #    from DUOAI_Strategy.populate_indicators.
+            #    The call to _get_talib_candlestick_patterns and its try-except block are removed.
+            #    candlestick_features_df variable is no longer created here.
+            logger.debug("Candlestick patterns are assumed to be pre-populated in the input dataframe.")
 
             # 3. Generate price-action features
             price_action_features_df = _get_price_action_features(base_ohlcv_df)
             logger.debug(f"Price-action features generated. Shape: {price_action_features_df.shape}")
 
             # 4. Concatenate all features
-            # Ensure indices align for concatenation. They should if base_ohlcv_df preserved index.
-            features_df = pd.concat([df_processed, candlestick_features_df, price_action_features_df], axis=1)
+            # Ensure indices align for concatenation.
+            # `candlestick_features_df` is removed as its columns are now part of `df_processed`.
+            features_df = pd.concat([df_processed, price_action_features_df], axis=1)
             logger.debug(f"Features concatenated. Shape: {features_df.shape}")
 
             # 5. Data Cleaning & Preparation for Scaling
@@ -485,55 +478,42 @@ class CNNPatterns:
 
     def detect_candlestick_patterns(self, candles_df: pd.DataFrame) -> Dict[str, bool]:
         patterns = {}
-        if candles_df.empty or len(candles_df) < 1: # Added len check for safety, though empty covers it.
+        if candles_df.empty: # Simplified check
             logger.warning("Input candles_df is empty in detect_candlestick_patterns.")
             return patterns
 
-        # Ensure DataFrame has standard OHLC column names (lowercase)
-        df_std = candles_df.copy()
-        df_std.rename(columns={
-            "Open": "open", "High": "high", "Low": "low", "Close": "close",
-            "OPEN": "open", "HIGH": "high", "LOW": "low", "CLOSE": "close"
-        }, inplace=True, errors='ignore')
+        # Patterns are now expected to be pre-calculated in candles_df by DUOAI_Strategy.
+        # Column names are expected like: cdl_DOJI, cdl_ENGULFING etc. (uppercase after cdl_)
+        # These columns should contain values like 0 (no pattern), 100 (bullish), -100 (bearish).
 
-        required_cols = ['open', 'high', 'low', 'close']
-        if not all(col in df_std.columns for col in required_cols):
-            logger.warning(f"Missing required OHLC columns in detect_candlestick_patterns. Got: {df_std.columns}.")
-            return patterns
-
-        if not hasattr(df_std, 'ta'):
-            logger.error("pandas_ta accessor '.ta' not found on DataFrame in detect_candlestick_patterns. Is pandas_ta installed and imported correctly as ta?")
-            return patterns
-
-        # Define patterns to check, mapping to pandas-ta function and output key
-        # Output keys match original (CDLDOJI, CDLENGULFING)
-        patterns_to_check = {
-            'CDLDOJI': 'cdl_doji',
-            'CDLENGULFING': 'cdl_engulfing',
-            # Add more here if this function was supposed to detect more than just these two.
-            # The original only explicitly calculated these two.
+        # Define the patterns this method should look for and their corresponding column names.
+        # The keys in this map ('CDLDOJI') are what this function will return.
+        # The values ('cdl_DOJI') are the column names expected in the input DataFrame.
+        patterns_to_check_map = {
+            "CDLDOJI": "cdl_DOJI",
+            "CDLENGULFING": "cdl_ENGULFING",
+            "CDLHAMMER": "cdl_HAMMER",
+            "CDLINVERTEDHAMMER": "cdl_INVERTEDHAMMER",
+            "CDLMORNINGSTAR": "cdl_MORNINGSTAR",
+            "CDLEVENINGSTAR": "cdl_EVENINGSTAR",
+            "CDLSHOOTINGSTAR": "cdl_SHOOTINGSTAR",
+            "CDL3WHITESOLDIERS": "cdl_3WHITESOLDIERS",
+            "CDL3BLACKCROWS": "cdl_3BLACKCROWS",
+            "CDLHARAMI": "cdl_HARAMI"
+            # Add more patterns here if DUOAI_Strategy calculates them and they are needed.
         }
 
-        for pattern_key, pta_func_name in patterns_to_check.items():
-            try:
-                if not hasattr(df_std.ta, pta_func_name):
-                    logger.warning(f"Pandas-ta function {pta_func_name} not found for {pattern_key}.")
-                    patterns[pattern_key] = False
-                    continue
-
-                indicator_function = getattr(df_std.ta, pta_func_name)
-                result_series = indicator_function() # e.g., df_std.ta.cdl_doji()
-
-                if result_series is not None and not result_series.empty:
-                    # Candlestick patterns in pandas-ta usually return non-zero (e.g., 100 for bullish, -100 for bearish) when a pattern is detected at a given candle.
-                    # A value of 0 means no pattern.
-                    # We check the last candle in the series.
-                    patterns[pattern_key] = bool(result_series.iloc[-1] != 0)
+        for pattern_key, column_name in patterns_to_check_map.items():
+            if column_name in candles_df.columns:
+                if not candles_df[column_name].empty:
+                    # Check the last candle. Non-zero means pattern detected.
+                    patterns[pattern_key] = bool(candles_df[column_name].iloc[-1] != 0)
                 else:
-                    logger.debug(f"Pandas-ta function {pta_func_name} for {pattern_key} returned None or empty series.")
+                    # Column exists but is empty, pattern not active on last candle
                     patterns[pattern_key] = False
-            except Exception as e:
-                logger.warning(f"Error calculating pandas-ta pattern {pta_func_name} for {pattern_key}: {e}")
+            else:
+                # Log if a specific column is missing, but don't error out, just mark pattern as False.
+                logger.debug(f"Candlestick pattern column '{column_name}' not found in DataFrame for key '{pattern_key}'.")
                 patterns[pattern_key] = False
 
         return {k: v for k, v in patterns.items() if v is True} # Return only True patterns
@@ -697,112 +677,8 @@ class CNNPatterns:
 
 # --- Helper Functions for Feature Engineering ---
 
-def _get_talib_candlestick_patterns(dataframe: pd.DataFrame) -> pd.DataFrame:
-    """
-    Calculates a wide range of candlestick patterns using pandas_ta.
-    Input: Freqtrade OHLCV DataFrame (base timeframe) with 'open', 'high', 'low', 'close' columns.
-    Output: DataFrame with candlestick pattern signals (0, 100, -100, or other values as per pandas_ta).
-    """
-    candlestick_features = pd.DataFrame(index=dataframe.index)
-
-    # Ensure DataFrame has standard OHLC column names (lowercase) expected by pandas_ta
-    df_std = dataframe.copy()
-    df_std.rename(columns={
-        "Open": "open", "High": "high", "Low": "low", "Close": "close", "Volume": "volume",
-        # Ensure all case variations map to lowercase
-        "OPEN": "open", "HIGH": "high", "LOW": "low", "CLOSE": "close", "VOLUME": "volume"
-    }, inplace=True, errors='ignore') # Use errors='ignore' if some columns might not exist
-
-    required_cols = ['open', 'high', 'low', 'close']
-    if not all(col in df_std.columns for col in required_cols):
-        logger.warning(f"Missing required OHLC columns (open, high, low, close) in _get_talib_candlestick_patterns. Got: {df_std.columns}. Cannot calculate patterns.")
-        return candlestick_features # Return empty DataFrame
-
-    # List of pandas-ta candlestick pattern function names (without the cdl_ prefix typically)
-    # Mapping to original talib_pattern_functions for column naming consistency if desired.
-    # Original talib_pattern_functions: CDLDOJI, CDLENGULFING, CDLHAMMER, CDLINVERTEDHAMMER, CDLMORNINGSTAR, CDLEVENINGSTAR, CDLSHOOTINGSTAR, CDL3WHITESOLDIERS, CDL3BLACKCROWS, CDLHARAMI
-    # pandas-ta functions are typically lowercase: doji, engulfing, hammer, etc.
-    # The resulting column names from pandas-ta might also be lowercase or include parameters.
-    # We aim for output columns like 'cdl_DOJI', 'cdl_ENGULFING' to somewhat match the old 'cdl_CDLDOJI' style but cleaner.
-
-    pta_pattern_map = {
-        # pandas-ta function name (or part of it) : Desired output suffix (UPPERCASE)
-        'doji': 'DOJI',
-        'engulfing': 'ENGULFING',
-        'hammer': 'HAMMER',
-        'invertedhammer': 'INVERTEDHAMMER',
-        'morningstar': 'MORNINGSTAR', # pandas-ta might have morningstar and morningdojistar
-        'eveningstar': 'EVENINGSTAR', # pandas-ta might have eveningstar and eveningdojistar
-        'shootingstar': 'SHOOTINGSTAR',
-        'whitesoldiers': '3WHITESOLDIERS', # pandas-ta cdl_threeoutside or cdl_3whitesoldiers
-        'blackcrows': '3BLACKCROWS',     # pandas-ta cdl_threeoutside or cdl_3blackcrows
-        'harami': 'HARAMI'
-        # Note: pandas-ta uses cdl_x for many patterns. Example: df.ta.cdl_doji()
-        # Some patterns like '3whitesoldiers' in pandas-ta might be `cdl_3whitesoldiers`.
-        # The exact function name needs to be verified in pandas-ta documentation if issues arise.
-    }
-
-    # Use a temporary DataFrame for pandas-ta to operate on, ensuring it has the right column names
-    temp_df_for_pta = df_std[required_cols].copy()
-
-    if not hasattr(temp_df_for_pta, 'ta'):
-        logger.error("pandas_ta accessor '.ta' not found on DataFrame. Is pandas_ta installed and imported correctly as ta?")
-        return candlestick_features
-
-    for pta_func_short_name, out_suffix_upper in pta_pattern_map.items():
-        target_col_name = f'cdl_{out_suffix_upper}'
-        try:
-            # Construct the full pandas-ta function name (e.g., cdl_doji)
-            pattern_func_name = f"cdl_{pta_func_short_name.lower()}"
-
-            # Get the indicator function from temp_df_for_pta.ta
-            indicator_function = getattr(temp_df_for_pta.ta, pattern_func_name)
-
-            if callable(indicator_function):
-                result_series = indicator_function() # Call the function
-                if isinstance(result_series, pd.Series):
-                    candlestick_features[target_col_name] = result_series.fillna(0)
-                elif isinstance(result_series, pd.DataFrame):
-                    # Some pta functions return a DataFrame with multiple columns,
-                    # e.g., MACD returns MACD_12_26_9, MACDh_12_26_9, MACDs_12_26_9
-                    # For candlestick patterns, it's usually a single series.
-                    # If it returns a DF, we need to know which column to pick or how to handle it.
-                    # Assuming the first column is the primary signal if a DF is returned by a cdl func.
-                    if not result_series.empty:
-                         # Prefer a column with a name similar to the pattern, or just the first one.
-                        # Example: if pattern_func_name is 'cdl_doji', pandas_ta might name the column 'CDL_DOJI_10_0.1'.
-                        # We need to find the relevant column.
-                        # For simplicity, if `result_series` is a DataFrame, we'll try to find a column containing the short name or just take the first.
-                        relevant_col = None
-                        for col in result_series.columns:
-                            if pta_func_short_name.lower() in col.lower():
-                                relevant_col = col
-                                break
-                        if relevant_col:
-                            candlestick_features[target_col_name] = result_series[relevant_col].fillna(0)
-                        elif not result_series.columns.empty : # Fallback to first column
-                            candlestick_features[target_col_name] = result_series.iloc[:, 0].fillna(0)
-                        else:
-                            logger.warning(f"Pandas-ta function {pattern_func_name} returned an empty DataFrame.")
-                            candlestick_features[target_col_name] = 0
-                    else:
-                        logger.warning(f"Pandas-ta function {pattern_func_name} returned an empty DataFrame.")
-                        candlestick_features[target_col_name] = 0
-                else:
-                    logger.warning(f"Pandas-ta function {pattern_func_name} did not return a Series or DataFrame for {pta_func_short_name}. Type: {type(result_series)}")
-                    candlestick_features[target_col_name] = 0
-            else:
-                logger.warning(f"Could not find callable pandas-ta function for {pattern_func_name} (from {pta_func_short_name}).")
-                candlestick_features[target_col_name] = 0
-        except AttributeError:
-            logger.warning(f"AttributeError: pandas-ta pattern function {pattern_func_name} (from {pta_func_short_name}) not found. Filling with 0.")
-            candlestick_features[target_col_name] = 0
-        except Exception as e:
-            logger.warning(f"Could not calculate pandas-ta pattern {pta_func_short_name} ({pattern_func_name}): {e}. Filling with 0.")
-            candlestick_features[target_col_name] = 0
-
-    logger.info(f"Candlestick features calculated using pandas-ta. Shape: {candlestick_features.shape}. Columns: {candlestick_features.columns.tolist()}")
-    return candlestick_features
+# _get_talib_candlestick_patterns function removed as candlestick patterns
+# are now expected to be generated by DUOAI_Strategy.populate_indicators.
 
 def _get_price_action_features(dataframe: pd.DataFrame) -> pd.DataFrame:
     """


### PR DESCRIPTION
This commit refactors `core/pre_trainer.py` and `core/backtester.py` to consume technical indicators as defined and populated by `DUOAI_Strategy.py`.

Changes include:
- `core/pre_trainer.py`:
    - Removed local calculation of RSI, MACD, and Bollinger Bands.
    - Added a helper method to process raw OHLCV data through `DUOAI_Strategy.advise_all_indicators()`.
    - `fetch_historical_data` now returns DataFrames enriched with all strategy indicators.
- `core/backtester.py`:
    - Removed the `_add_indicators` method.
    - `run_backtest` now processes fetched OHLCV data through `DUOAI_Strategy.advise_all_indicators()`.
- `strategies/DUOAI_Strategy.py`:
    - The `populate_indicators` method was extended to calculate a standard set of candlestick patterns (e.g., DOJI, ENGULFING, HAMMER) using `pandas-ta` for both base and informative timeframes.
- `core/cnn_patterns.py`:
    - Removed its internal candlestick pattern calculation function (`_get_talib_candlestick_patterns`).
    - `prepare_cnn_features` now expects candlestick patterns to be present in the input DataFrame (provided by `PreTrainer`).
    - `detect_candlestick_patterns` was updated to read these pre-calculated candlestick columns.

This centralization ensures that all components of the system (Freqtrade engine, custom backtesting, AI model pre-training) use a single, uniform source for indicator data, enhancing consistency and maintainability.