### PR TITLE
feat: Integrate sentiment into decision-making and learning loops

### DIFF
--- a/core/bias_reflector.py
+++ b/core/bias_reflector.py
@@ -51,7 +51,11 @@ class BiasReflector:
         """
         return self.bias_memory.get(token, {}).get(strategy_id, {}).get('bias', 0.5)
 
-    async def update_bias(self, token: str, strategy_id: str, new_ai_bias: float, confidence: float, trade_result_pct: Optional[float] = None):
+    async def update_bias(self, token: str, strategy_id: str, new_ai_bias: float, confidence: float,
+                          trade_result_pct: Optional[float] = None,
+                          sentiment_data_status: Optional[str] = None,
+                          first_sentiment_observed: Optional[str] = None,
+                          trade_direction: Optional[str] = None):
         """
         Werkt de bias score bij op basis van AI-reflectie en trade resultaat.
         Implementeert een cooldown om te snelle aanpassingen te voorkomen.
@@ -102,6 +106,39 @@ class BiasReflector:
             # Dit is een standaard gewogen gemiddelde update.
             calculated_new_bias = (current_bias * (1 - confidence) + new_ai_bias * confidence)
 
+        # Sentiment-Based Adjustment (only if trade_result_pct is present)
+        if trade_result_pct is not None and sentiment_data_status == "present_and_not_empty" and first_sentiment_observed and trade_direction:
+            sentiment_influence_weight = 0.05  # Weight for sentiment influence
+            sentiment_aligned_with_profit = False
+            sentiment_misaligned_with_profit = False
+
+            if trade_direction == "long":
+                if first_sentiment_observed == "positive" and trade_result_pct > 0: sentiment_aligned_with_profit = True
+                elif first_sentiment_observed == "negative" and trade_result_pct <= 0: sentiment_aligned_with_profit = True
+                elif first_sentiment_observed == "positive" and trade_result_pct <= 0: sentiment_misaligned_with_profit = True
+                elif first_sentiment_observed == "negative" and trade_result_pct > 0: sentiment_misaligned_with_profit = True
+            elif trade_direction == "short":
+                if first_sentiment_observed == "negative" and trade_result_pct > 0: sentiment_aligned_with_profit = True
+                elif first_sentiment_observed == "positive" and trade_result_pct <= 0: sentiment_aligned_with_profit = True
+                elif first_sentiment_observed == "negative" and trade_result_pct <= 0: sentiment_misaligned_with_profit = True # Negative sentiment, but short lost (profit <=0)
+                elif first_sentiment_observed == "positive" and trade_result_pct > 0: sentiment_misaligned_with_profit = True # Positive sentiment, but short won (profit > 0)
+
+            sentiment_nudge = 0.0
+            if sentiment_aligned_with_profit:
+                adjustment_direction = 0
+                if first_sentiment_observed == "positive": adjustment_direction = 1
+                elif first_sentiment_observed == "negative": adjustment_direction = -1
+                sentiment_nudge = sentiment_influence_weight * confidence * adjustment_direction
+                calculated_new_bias += sentiment_nudge
+                logger.info(f"[BiasReflector] Sentiment ALIGNED ({first_sentiment_observed} for {trade_direction}, outcome {trade_result_pct:.2%}). Nudging bias by {sentiment_nudge:.4f}.")
+            elif sentiment_misaligned_with_profit:
+                adjustment_direction = 0
+                if first_sentiment_observed == "positive": adjustment_direction = -1 # Positive sentiment was wrong
+                elif first_sentiment_observed == "negative": adjustment_direction = 1  # Negative sentiment was wrong
+                sentiment_nudge = sentiment_influence_weight * confidence * adjustment_direction
+                calculated_new_bias += sentiment_nudge
+                logger.info(f"[BiasReflector] Sentiment MISALIGNED ({first_sentiment_observed} for {trade_direction}, outcome {trade_result_pct:.2%}). Nudging bias by {sentiment_nudge:.4f}.")
+
         # Zorg dat bias tussen 0 en 1 blijft
         calculated_new_bias = max(0.0, min(1.0, calculated_new_bias))
 
@@ -113,3 +150,193 @@ class BiasReflector:
 
         await asyncio.to_thread(self._save_bias_memory)
         logger.info(f"[BiasReflector] Bias voor {token}/{strategy_id} bijgewerkt naar {calculated_new_bias:.3f} (was {current_bias:.3f}).")
+
+
+# Test sectie
+async def run_test_bias_reflector():
+    # Corrected path for .env when running this script directly
+    dotenv_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '.env')
+    dotenv.load_dotenv(dotenv_path)
+
+    # Setup basic logging for the test
+    import sys
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                        handlers=[logging.StreamHandler(sys.stdout)])
+
+    reflector = BiasReflector()
+
+    # Clean up memory file before test if it exists
+    if os.path.exists(BIAS_MEMORY_FILE):
+        os.remove(BIAS_MEMORY_FILE)
+        reflector = BiasReflector() # Re-initialize to ensure clean state
+
+    # Test 1: Initial bias
+    initial_bias = reflector.get_bias_score("BTC", "strategy1")
+    logger.info(f"Test 1: Initial bias for BTC/strategy1: {initial_bias}")
+    assert initial_bias == 0.5
+
+    # Test 2: Update bias with no trade result (AI suggestion only)
+    logger.info("\n--- Test 2: Update bias (AI suggestion only) ---")
+    await reflector.update_bias("BTC", "strategy1", new_ai_bias=0.7, confidence=0.8)
+    updated_bias_no_trade = reflector.get_bias_score("BTC", "strategy1")
+    # Expected: (0.5 * 0.2) + (0.7 * 0.8) = 0.1 + 0.56 = 0.66
+    logger.info(f"Test 2: Bias after AI suggestion (0.7 conf 0.8): {updated_bias_no_trade}")
+    assert abs(updated_bias_no_trade - 0.66) < 0.001
+
+    # Test 3: Update bias with profitable trade
+    logger.info("\n--- Test 3: Update bias (Profitable Trade) ---")
+    # Current bias is 0.66. AI suggests 0.7 (new_ai_bias). Confidence 0.8. Trade profit 5%.
+    # trade_influence_factor = 0.8 * 0.1 = 0.08
+    # target_bias = new_ai_bias (0.7) because 0.7 > 0.66
+    # adjustment = (0.7 - 0.66) * 0.08 * (1 + min(0.05 * 10, 1)) = 0.04 * 0.08 * 1.5 = 0.0048
+    # calculated_new_bias = 0.66 + 0.0048 = 0.6648
+    await reflector.update_bias("BTC", "strategy1", new_ai_bias=0.7, confidence=0.8, trade_result_pct=0.05)
+    updated_bias_profit = reflector.get_bias_score("BTC", "strategy1")
+    logger.info(f"Test 3: Bias after profitable trade (+5%): {updated_bias_profit}")
+    assert abs(updated_bias_profit - 0.6648) < 0.001
+
+
+    # Test 4: Update bias with losing trade
+    logger.info("\n--- Test 4: Update bias (Losing Trade) ---")
+    # Current bias is 0.6648. AI suggests 0.3 (new_ai_bias). Confidence 0.6. Trade loss -3%.
+    # trade_influence_factor = 0.6 * 0.1 = 0.06
+    # target_bias = new_ai_bias (0.3) because 0.3 < 0.6648
+    # adjustment = (0.3 - 0.6648) * 0.06 * (1 + min(abs(-0.03) * 10, 1)) = -0.3648 * 0.06 * 1.3 = -0.0284544
+    # calculated_new_bias = 0.6648 - 0.0284544 = 0.6363456
+    await reflector.update_bias("BTC", "strategy1", new_ai_bias=0.3, confidence=0.6, trade_result_pct=-0.03)
+    updated_bias_loss = reflector.get_bias_score("BTC", "strategy1")
+    logger.info(f"Test 4: Bias after losing trade (-3%): {updated_bias_loss}")
+    assert abs(updated_bias_loss - 0.6363456) < 0.001
+
+    # Test 5: Cooldown
+    logger.info("\n--- Test 5: Cooldown Check ---")
+    # Bias is 0.6363456. Last update was just now.
+    await reflector.update_bias("BTC", "strategy1", new_ai_bias=0.9, confidence=0.9, trade_result_pct=0.10) # This should be blocked by cooldown
+    bias_after_cooldown_attempt = reflector.get_bias_score("BTC", "strategy1")
+    logger.info(f"Test 5: Bias after cooldown attempt: {bias_after_cooldown_attempt}")
+    assert abs(bias_after_cooldown_attempt - updated_bias_loss) < 0.001 # Bias should not have changed
+
+    # --- Sentiment-based Adjustment Tests ---
+    # Reset memory for these specific tests for clarity, or use a new token/strategy
+    if os.path.exists(BIAS_MEMORY_FILE):
+        os.remove(BIAS_MEMORY_FILE)
+    reflector = BiasReflector() # Re-initialize
+
+    logger.info("\n--- Test 6: Profitable LONG, POSITIVE sentiment (Aligned) ---")
+    # Initial bias = 0.5. AI suggests 0.7 (bullish). Confidence 0.8. Profit 5%.
+    # Standard adjustment:
+    # trade_influence_factor = 0.8 * 0.1 = 0.08
+    # target_bias = new_ai_bias (0.7) because 0.7 > 0.5
+    # adjustment = (0.7 - 0.5) * 0.08 * (1 + min(0.05*10,1)) = 0.2 * 0.08 * 1.5 = 0.024
+    # calculated_new_bias (before sentiment) = 0.5 + 0.024 = 0.524
+    # Sentiment nudge:
+    # sentiment_influence_weight = 0.05. first_sentiment_observed="positive" -> adjustment_direction = 1
+    # sentiment_nudge = 0.05 * 0.8 * 1 = 0.04
+    # final_calculated_new_bias = 0.524 + 0.04 = 0.564
+    await reflector.update_bias("SENT", "long_positive_profit", new_ai_bias=0.7, confidence=0.8, trade_result_pct=0.05,
+                                sentiment_data_status="present_and_not_empty",
+                                first_sentiment_observed="positive",
+                                trade_direction="long")
+    final_bias_t6 = reflector.get_bias_score("SENT", "long_positive_profit")
+    logger.info(f"Test 6: Bias = {final_bias_t6:.4f}")
+    assert abs(final_bias_t6 - 0.564) < 0.0001
+
+    logger.info("\n--- Test 7: Unprofitable LONG, POSITIVE sentiment (Misaligned) ---")
+    # Initial bias = 0.5. AI suggests 0.7 (bullish). Confidence 0.8. Loss -3%.
+    # Standard adjustment:
+    # trade_influence_factor = 0.8 * 0.1 = 0.08
+    # target_bias = new_ai_bias (0.7) because 0.7 > 0.5
+    # adjustment = (0.7 - 0.5) * 0.08 * (1 + min(0.03*10,1)) = 0.2 * 0.08 * 1.3 = 0.0208
+    # calculated_new_bias (before sentiment) = 0.5 + 0.0208 = 0.5208 -> This is wrong logic for loss, let's re-evaluate.
+    # If loss: target_bias = new_ai_bias (0.7) if new_ai_bias < current_bias (0.5) -> False. So, target_bias = 0.5 - 0.05 = 0.45
+    # adjustment = (0.45 - 0.5) * 0.08 * 1.3 = -0.05 * 0.08 * 1.3 = -0.0052
+    # calculated_new_bias (before sentiment) = 0.5 - 0.0052 = 0.4948
+    # Sentiment nudge (misaligned):
+    # first_sentiment_observed="positive" -> adjustment_direction = -1
+    # sentiment_nudge = 0.05 * 0.8 * (-1) = -0.04
+    # final_calculated_new_bias = 0.4948 - 0.04 = 0.4548
+    await reflector.update_bias("SENT", "long_positive_loss", new_ai_bias=0.7, confidence=0.8, trade_result_pct=-0.03,
+                                sentiment_data_status="present_and_not_empty",
+                                first_sentiment_observed="positive",
+                                trade_direction="long")
+    final_bias_t7 = reflector.get_bias_score("SENT", "long_positive_loss")
+    logger.info(f"Test 7: Bias = {final_bias_t7:.4f}")
+    assert abs(final_bias_t7 - 0.4548) < 0.0001
+
+
+    logger.info("\n--- Test 8: Profitable SHORT, NEGATIVE sentiment (Aligned) ---")
+    # Initial bias = 0.5. AI suggests 0.3 (bearish). Confidence 0.8. Profit 5% (for short).
+    # Standard adjustment (profit):
+    # trade_influence_factor = 0.8 * 0.1 = 0.08
+    # target_bias = new_ai_bias (0.3) because 0.3 < 0.5
+    # adjustment = (0.3 - 0.5) * 0.08 * (1 + min(0.05*10,1)) = -0.2 * 0.08 * 1.5 = -0.024
+    # calculated_new_bias (before sentiment) = 0.5 - 0.024 = 0.476
+    # Sentiment nudge (aligned):
+    # first_sentiment_observed="negative" -> adjustment_direction = -1
+    # sentiment_nudge = 0.05 * 0.8 * (-1) = -0.04
+    # final_calculated_new_bias = 0.476 - 0.04 = 0.436
+    await reflector.update_bias("SENT", "short_negative_profit", new_ai_bias=0.3, confidence=0.8, trade_result_pct=0.05,
+                                sentiment_data_status="present_and_not_empty",
+                                first_sentiment_observed="negative",
+                                trade_direction="short")
+    final_bias_t8 = reflector.get_bias_score("SENT", "short_negative_profit")
+    logger.info(f"Test 8: Bias = {final_bias_t8:.4f}")
+    assert abs(final_bias_t8 - 0.436) < 0.0001
+
+    logger.info("\n--- Test 9: Unprofitable SHORT (loss for short means price went up), NEGATIVE sentiment (Misaligned) ---")
+    # Initial bias = 0.5. AI suggests 0.3 (bearish). Confidence 0.8. Loss -3% (for short, means price increased).
+    # Standard adjustment (loss):
+    # trade_influence_factor = 0.8 * 0.1 = 0.08
+    # target_bias = new_ai_bias (0.3) if new_ai_bias < current_bias (0.5) -> True. So target_bias = 0.3
+    # adjustment = (0.3 - 0.5) * 0.08 * (1 + min(0.03*10,1)) = -0.2 * 0.08 * 1.3 = -0.0208
+    # calculated_new_bias (before sentiment) = 0.5 - 0.0208 = 0.4792
+    # Sentiment nudge (misaligned):
+    # first_sentiment_observed="negative" -> adjustment_direction = 1 (negative sentiment was wrong for a short that lost value)
+    # sentiment_nudge = 0.05 * 0.8 * 1 = 0.04
+    # final_calculated_new_bias = 0.4792 + 0.04 = 0.5192
+    await reflector.update_bias("SENT", "short_negative_loss", new_ai_bias=0.3, confidence=0.8, trade_result_pct=-0.03,
+                                sentiment_data_status="present_and_not_empty",
+                                first_sentiment_observed="negative",
+                                trade_direction="short")
+    final_bias_t9 = reflector.get_bias_score("SENT", "short_negative_loss")
+    logger.info(f"Test 9: Bias = {final_bias_t9:.4f}")
+    assert abs(final_bias_t9 - 0.5192) < 0.0001
+
+
+    logger.info("\n--- Test 10: Profitable LONG, NEUTRAL sentiment ---")
+    # Initial bias = 0.5. AI suggests 0.7 (bullish). Confidence 0.8. Profit 5%.
+    # Standard adjustment: 0.524 (same as Test 6 before sentiment)
+    # Sentiment nudge (neutral):
+    # first_sentiment_observed="neutral" -> adjustment_direction = 0
+    # sentiment_nudge = 0.05 * 0.8 * 0 = 0.0
+    # final_calculated_new_bias = 0.524 + 0.0 = 0.524
+    await reflector.update_bias("SENT", "long_neutral_profit", new_ai_bias=0.7, confidence=0.8, trade_result_pct=0.05,
+                                sentiment_data_status="present_and_not_empty",
+                                first_sentiment_observed="neutral",
+                                trade_direction="long")
+    final_bias_t10 = reflector.get_bias_score("SENT", "long_neutral_profit")
+    logger.info(f"Test 10: Bias = {final_bias_t10:.4f}")
+    assert abs(final_bias_t10 - 0.524) < 0.0001
+
+    logger.info("\n--- Test 11: Profitable LONG, sentiment data ABSENT ---")
+    # Initial bias = 0.5. AI suggests 0.7 (bullish). Confidence 0.8. Profit 5%.
+    # Standard adjustment: 0.524 (same as Test 6 before sentiment)
+    # Sentiment nudge: Should not occur.
+    # final_calculated_new_bias = 0.524
+    await reflector.update_bias("SENT", "long_no_sentiment_profit", new_ai_bias=0.7, confidence=0.8, trade_result_pct=0.05,
+                                sentiment_data_status="absent", # Crucial part
+                                first_sentiment_observed=None,
+                                trade_direction="long")
+    final_bias_t11 = reflector.get_bias_score("SENT", "long_no_sentiment_profit")
+    logger.info(f"Test 11: Bias = {final_bias_t11:.4f}")
+    assert abs(final_bias_t11 - 0.524) < 0.0001
+
+
+    logger.info("\nAll BiasReflector tests passed.")
+    # Clean up memory file after test
+    if os.path.exists(BIAS_MEMORY_FILE):
+        os.remove(BIAS_MEMORY_FILE)
+
+if __name__ == '__main__':
+    asyncio.run(run_test_bias_reflector())


### PR DESCRIPTION
This commit implements the second phase of social sentiment integration, focusing on its use in trade execution decisions and its role in the system's learning and adaptation mechanisms.

Key changes include:

1.  **Decision Logic (`entry_decider.py`, `exit_optimizer.py`):**
    *   Ensured `additional_context` (potentially containing
        `social_sentiment_grok` data) is correctly passed to the
        `PromptBuilder` when generating prompts for both entry and exit
        decisions.
    *   Added logging to these modules to indicate whether social
        sentiment data was present in the prompt context, providing
        traceability.

2.  **Reflection Loop (`reflectie_lus.py`):**
    *   Enhanced the trade reflection process to log detailed sentiment
        information if it was part of the original prompt. This includes:
        *   `sentiment_data_status`: Indicates presence and state (e.g.,
            empty, not empty).
        *   `sentiment_items_logged`: A list of actual sentiment values
            observed.
        *   `sentiment_trade_correlation_notes`: A textual summary of
            how the primary sentiment correlated with the trade's outcome.
    *   Updated calls to `BiasReflector.update_bias` and
        `ConfidenceEngine.update_confidence` to pass this new sentiment
        context (status, first observed sentiment, and trade direction).
        (Note: Assumes `trade_direction` is made available in `trade_context`
        by the calling system).

3.  **Bias Adaptation (`bias_reflector.py`):**
    *   Modified `update_bias` to accept sentiment status, observed
        sentiment, and trade direction.
    *   Introduced a "sentiment nudge" to the bias score. If sentiment
        data was present for a trade, the bias is further adjusted
        based on whether the sentiment aligned with a profitable outcome
        (considering trade direction).

4.  **Confidence Adaptation (`confidence_engine.py`):**
    *   Modified `update_confidence` to also accept the new sentiment
        parameters.
    *   Applies a "sentiment nudge" to both the learned confidence score
        and the `max_per_trade_pct` (stake size variable). This adjustment
        is positive if sentiment aligned with trade profitability and
        negative if misaligned.

**Your Feedback Incorporated:**
*   You approved the general direction of these changes.

**Future Work (Your Request):**
*   You have requested that the README be updated to reflect these
    new functionalities. I will address this in a subsequent session.

This set of changes aims to make the trading bot more adaptive by learning from the effectiveness of social media sentiment analysis.