### PR TITLE
Refactor: Improve project structure and Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /freqtrade
 COPY requirements.txt /freqtrade/requirements.txt
 
 RUN pip install --upgrade pip
-RUN pip install --no-cache-dir -r /freqtrade/requirements.txt --break-system-packages
+RUN pip install --no-cache-dir --force-reinstall -r /freqtrade/requirements.txt --break-system-packages
 
 COPY ./user_data /freqtrade/user_data/
 COPY ./core /freqtrade/core/

--- a/ft_userdata/docker-compose.yml
+++ b/ft_userdata/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - "../user_data:/freqtrade/user_data"
       - "../config:/freqtrade/config"
-      - "../strategies:/freqtrade/strategies"
+      - "../strategies:/freqtrade/user_data/strategies"
       - "../core:/freqtrade/core"
     environment:
       - "PYTHONPATH=/freqtrade"


### PR DESCRIPTION
This commit addresses several issues related to project structure, Docker configuration, and dependency installation to ensure the Freqtrade bot runs reliably.

Key changes include:

1.  **Corrected Docker Compose Volume Mount:** The `docker-compose.yml` now correctly mounts the local `./strategies` directory to `/freqtrade/user_data/strategies/` in the container. This aligns the development environment with Freqtrade's expected strategy path.

2.  **Enhanced Dockerfile pip Install:** Added the `--force-reinstall` flag to `pip install -r requirements.txt` in the Dockerfile. This helps prevent binary incompatibility issues by ensuring a clean installation of dependencies.

3.  **Ensured `utils/__init__.py`:** Created `utils/__init__.py` to define the `utils` directory as a Python package, enabling proper module imports from this directory.

4.  **Verified Critical Files:** Confirmed that `strategies/indicators/custom_indicators.py` is not empty and contains the necessary indicator definitions.

These changes aim to resolve previous import errors, configuration conflicts, and potential runtime issues, leading to a more stable and maintainable bot deployment. The strategy files located in the root `strategies/` directory are now consistently used as the source of truth.